### PR TITLE
Use bearer auth for AppSearch client

### DIFF
--- a/django_elastic_appsearch/__init__.py
+++ b/django_elastic_appsearch/__init__.py
@@ -3,4 +3,4 @@
 # pylint:disable=invalid-name
 # Django requires `default_app_config`
 default_app_config = 'django_elastic_appsearch.apps.DjangoAppSearchConfig'
-__version__ = '1.3.0'
+__version__ = '1.3.1'

--- a/django_elastic_appsearch/clients.py
+++ b/django_elastic_appsearch/clients.py
@@ -41,4 +41,4 @@ def get_api_v1_enterprise_search_client():
         appsearch_host
     )
 
-    return AppSearch(url, http_auth=api_key, **config.extra_config_options)
+    return AppSearch(url, bearer_auth=api_key, **config.extra_config_options)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0
+current_version = 1.3.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ history = open('HISTORY.rst', encoding='utf-8').read().replace('.. :changelog:',
 
 setup(
     name='django_elastic_appsearch',
-    version='1.3.0',
+    version='1.3.1',
     description="""Integrate your Django Project with Elastic App Search with ease.""",
     long_description=readme + '\n\n' + history,
     author='Infoxchange',


### PR DESCRIPTION
We use the bearer auth for the AppSearch client to be compatible with appsearch 1.8.4